### PR TITLE
Fix actions

### DIFF
--- a/.github/workflows/crates.io.yml
+++ b/.github/workflows/crates.io.yml
@@ -26,6 +26,9 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
-    - run: cargo publish --token ${CRATES_TOKEN} -p dropin-compiler
+    - run: cargo publish --token ${CRATES_TOKEN}
+      env:
+        CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    - run: cargo publish --token ${CRATES_TOKEN} -p dropin-bootstrap
       env:
         CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The workflow `crates.io.yml` was publishing a deleted package: `dropin-compiler`. It now publishes the CLI and boostrap.